### PR TITLE
Condor integration, 2 example IEs, documentation and a bunch of comments

### DIFF
--- a/config/plugins/interactive_environments/cellxgene/docker/Dockerfile
+++ b/config/plugins/interactive_environments/cellxgene/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.6.8-slim
  
-RUN pip3 install cellxgene && rm -rf ~/.cache
+RUN pip3 install cellxgene scanpy==1.4 && rm -rf ~/.cache
 
 ADD ./run_cellxgene.sh /
 
-ENTRYPOINT ["/run_cellxgene.sh"]
+##ENTRYPOINT ["/run_cellxgene.sh"]
 
 EXPOSE 80

--- a/config/plugins/interactive_environments/cellxgene/docker/run_cellxgene.sh
+++ b/config/plugins/interactive_environments/cellxgene/docker/run_cellxgene.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cellxgene launch --host 0.0.0.0 --port 80 /input/file.*
+cellxgene launch --host 0.0.0.0 --port 8080 /tmp/galaxy_cellxgene*

--- a/doc/source/admin/special_topics/interactive_tools.rst
+++ b/doc/source/admin/special_topics/interactive_tools.rst
@@ -1,0 +1,71 @@
+Galaxy Interactive Tools/Environments
+=====================================
+
+A GIE is a Docker container, launched by Galaxy, proxied by Galaxy, with some
+extra sugar inside the container to allow users to interact easily with their
+Galaxy histories if needed.
+
+How GIEs Work
+-------------
+
+A GIE is primarily composed of a Docker container, and the Galaxy tools framework.
+
+At first, make sure your Galaxy tool runner does support the Interactive Environments.
+Currently, only the **local** runner (which is not recommended for production) and the **condor** runner
+do support the IE2.
+
+Make sure to enable the Docker support in your destination.
+
+.. code-block:: xml
+
+        <destination id="condor" runner="condor">
+            <param id="docker_enabled">true</param>
+            <param id="docker_sudo">false</param>
+        </destination>
+
+        <destination id="local" runner="local">
+            <param id="docker_enabled">true</param>
+            <param id="docker_sudo">false</param>
+        </destination>
+
+As a next step, you need to activate the uwsgi proxy by adding the following configurations to your **galaxy.yml** file.
+This goes into your **uwsgi:** section.
+
+.. code-block:: yaml
+  http-raw-body: true
+  # master: true
+
+  realtime_map: database/realtime_map.sqlite
+  python-raw: scripts/realtime/key_type_token_mapping.py
+  route-host: ^([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.(realtime\.localhost:8080)$ goto:realtime
+  route-run: goto:endendend
+  route-label: realtime
+  route-host: ^([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.(realtime\.localhost:8080)$ rpcvar:TARGET_HOST rtt_key_type_token_mapper_cached $2 $1 $3 $4 $0 5
+  route-if-not: empty:${TARGET_HOST} httpdumb:${TARGET_HOST}
+  route-label: endendend
+
+And this, into your **galaxy:** section:
+
+.. code-block:: yaml
+
+  realtime_prefix: realtime
+
+
+Now you can add two test IE tools to your setup by including the following two lines into your tool_conf.xml file.
+
+.. code-block:: xml
+
+    <tool file="../test/functional/tools/interactive_tool_juypter_notebook.xml" />
+    <tool file="../test/functional/tools/interactive_tools_cellxgene.xml" />
+
+Thats it. After restarting Galaxy you should be able to use these tools. Each of them will start a Docker container via
+the tool dependency mechanism and connects you to it via the uwsgi proxy.
+
+A few words to the condor integration
+-------------------------------------
+
+Galaxy needs to be able to stop a container gracefully. This is not a problem with the local job runner, where we assume that Docker is either running on the same host. However, if you are using production scale DRM, like condor, then your job is running
+somewhere on your cluster and you can not easily **docker stop** your container. For the condor integration we are using a great
+condor feature and commandline utlility called **condor_ssh_to_job**. This tool (assuming your condor setup is configured correctly) will bring us directly to the host in question and we can execute the **docker stop** command. Galaxy will simply run **condor_ssh_to_job <condor_job_id> docker stop <container_name>** to stop the container gracefully.
+
+Also please keep in mind that DRM usually have a max runtime configured for jobs. From the Galaxy point of view such a container could run as long as the user want, obviously this is not scaleable and you need to restrict the runtime of IE (or jobs in general). However, if the job is killed by the DRM the user is not informed beforehand and data in the container could be lost.

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -181,7 +181,7 @@ class LocalJobRunner(BaseJobRunner):
                 return
         else:
             log.warning("stop_job(): %s: PID %d refuses to die after signaling TERM/KILL" % (job.id, pid))
-        self.__kill_container(job_wrapper)
+        self._kill_container(job_wrapper)
 
     def recover(self, job, job_wrapper):
         # local jobs can't be recovered
@@ -282,7 +282,6 @@ class LocalJobRunner(BaseJobRunner):
                                 t = 2 * i
                                 log.debug("Container not found during port check, sleeping for %s seconds.", t)
                                 sleep(t)
-
                         if ports_raw is not None:
                             self.app.realtime_manager.configure_entry_points_raw_docker_ports(job, ports_raw)
                         else:

--- a/lib/galaxy/tools/deps/container_classes.py
+++ b/lib/galaxy/tools/deps/container_classes.py
@@ -273,7 +273,7 @@ class DockerContainer(Container, HasDockerLikeVolumes):
             volumes_from=volumes_from,
             env_directives=env_directives,
             working_directory=working_directory,
-            net=self.prop("net", "none"),  # By default, docker instance has networking disabled
+            net=self.prop("net", None),  # By default, docker instance has networking disabled
             auto_rm=asbool(self.prop("auto_rm", docker_util.DEFAULT_AUTO_REMOVE)),
             set_user=self.prop("set_user", docker_util.DEFAULT_SET_USER),
             run_extra_arguments=self.prop("run_extra_arguments", docker_util.DEFAULT_RUN_EXTRA_ARGUMENTS),

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -200,9 +200,10 @@ class XmlToolSource(ToolSource):
             return ports
         for port_el in ports_el.findall("port"):
             port = port_el.text.strip()
-            url = port_el.find("url")
+            url = port_el.get("url_entry_point")
+            #url = port_el.find("url")
             if url is not None:
-                url = url.text.strip()
+                url = url.strip()
             name = port_el.get('name', None)
             if name:
                 name = name.strip()

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -220,7 +220,7 @@ For more information, see https://planemo.readthedocs.io/en/latest/writing_advan
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 
-This is a container tag set for the ``port`` and ``url`` tags
+This is a container tag set for the ``port`` and ``url_entry_point`` tags
 described in greater detail below. ``ports``s describe RealTimeTool entry points
 to a tool.
 
@@ -241,7 +241,7 @@ to provide access to graphical tools in real time.
 
 ```xml
 <ports>
-    <port name="Example name">80<url>landing/index.html</url></port>
+    <port name="Example name" url_entry_point="landing/index.html">80</port>
 </ports>
 ```
 
@@ -255,15 +255,11 @@ to provide access to graphical tools in real time.
             <xs:documentation xml:lang="en">This value defines the name of the entry point.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="PortURL">
-    <xs:annotation>
-      <xs:documentation xml:lang="en"><![CDATA[
-
-This tag set is contained within the ``<port>`` tag set. It contains the entry URL.
-
-]]></xs:documentation>
-    </xs:annotation>
+        <xs:attribute name="url_entry_point" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">This value defines the URL entry point of a service. This is the last part after the port number, e.g. a landing page.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ToolAction">

--- a/lib/galaxy/webapps/galaxy/controllers/realtime.py
+++ b/lib/galaxy/webapps/galaxy/controllers/realtime.py
@@ -102,7 +102,7 @@ class RealTime(BaseUIController):
                     rval = '%s//%s.%s.%s.%s.%s/' % (trans.request.host_url.split('//', 1)[0], entry_point.__class__.__name__.lower(), trans.security.encode_id(entry_point.id),
                             entry_point.token, trans.app.config.realtime_prefix, trans.request.host)
                     if entry_point.entry_url:
-                        rval = '%s%s' % (rval, entry_point.entry_url)
+                        rval = '%s/%s' % (rval.rstrip('/'), entry_point.entry_url.lstrip('/'))
                     return trans.response.send_redirect(rval)
                 elif entry_point.deleted:
                     return trans.show_error_message('RealTimeTool has ended. You will have to start a new one.')

--- a/test/functional/tools/default_notebook.ipynb
+++ b/test/functional/tools/default_notebook.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Welcome to the interactive Galaxy IPython Notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can access your data via the dataset number. Using a Python kernel, you can access dataset number 42 with ``handle = open(get(42), 'r')``.\n",
+    "To save data, write your data to a file, and then call ``put('filename.txt')``. The dataset will then be available in your galaxy history.\n<br>",
+    "When using a non-Python kernel, ``get`` and ``put`` are available as command-line tools, which can be accessed using system calls in R, Julia, and Ruby. For example, to read dataset number 42 into R, you can write ```handle <- file(system('get -i 42', intern = TRUE))```.\n",
+    "To save data in R, write the data to a file and then call ``system('put -p filename.txt')``.\n",
+    "Notebooks can be saved to Galaxy by clicking the large green button at the top right of the IPython interface.<br>\n",
+    "More help and informations can be found on the project [website](https://github.com/bgruening/docker-jupyter-notebook)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/test/functional/tools/interactive_tool_juypter_notebook.xml
+++ b/test/functional/tools/interactive_tool_juypter_notebook.xml
@@ -1,0 +1,77 @@
+<tool id="interactive_tool_juypter_notebook" tool_type="realtime" name="Interactive Jupyter Notebook" version="0.1">
+    <requirements>
+        <container type="docker">bgruening/docker-jupyter-notebook:ie2</container>
+    </requirements>
+    <ports>
+        <port name="Jypter Interactive Environment" url_entry_point="ipython/tree">8888</port>
+    </ports>
+    <command detect_errors="aggressive"><![CDATA[
+        #import re
+        export GALAXY_WORKING_DIR=`pwd` &&
+        mkdir -p ./jupyter/outputs/ &&
+        mkdir -p ./jupyter/data &&
+
+        #for $i, $input in enumerate($inputs):
+            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
+            ln -sf '$input' './jupyter/data/${cleaned_name}_${i}' &&
+        #end for
+
+        ## change into the directory where the notebooks are located
+        cd ./jupyter/ &&
+
+        #if $mode.mode_select == 'scratch':
+            ## copy default notebook
+            cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
+            /startup.sh
+        #else:
+
+            #for $i, $ipynb in enumerate($mode.ipynbs):
+                #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
+                cp '$ipynb' ./${cleaned_name}_${i}.ipynb &&
+            #end for
+            #if $mode.run_it:
+                jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
+                mv ./ipython_galaxy_notebook.ipynb $jupyter_notebook
+            #else:
+                /startup.sh
+            #end if
+
+        #end if
+    ]]>
+    </command>
+    <inputs>
+
+        <conditional name="mode">
+            <param argument="mode_select" type="select" label="Do you already have a notebook?" help="If not, no problem we will provide you with a default one.">
+                <option value="scratch">Start with a fresh notebook</option>
+                <option value="previous">Load a previous notebook</option>
+            </param>
+            <when value="scratch"/>
+            <when value="previous">
+                <param name="ipynbs" type="data" format="ipynb" multiple="true" label="IPython Notebook"/>
+                <param name="run_it" type="boolean" truevalue="true" falsevalue="false" label="Execute notebook and return a new one."
+                    help="This option is useful in workflows when you just want to execute a notebook and not dive into the webfrontend."/>
+            </when>
+        </conditional>
+
+        <param name="inputs" type="data" optional="true" multiple="true" label="Include data into the environment"/>
+
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt">
+            <filter>(mode['mode_select'] == 'previous' and not mode['run_it']) or mode['mode_select'] == 'scratch'</filter>
+        </data>
+        <data name="jupyter_notebook" format="ipynb" label="Executed Notebook">
+            <filter>mode['mode_select'] == 'previous'</filter>
+            <filter>mode['run_it']</filter>
+        </data>
+        <!--data auto_format="true" name="collected_container_data">
+            <discover_datasets pattern="__designation__" directory="./jupyter/outputs/" visible="true" recurse="true" />
+        </data-->
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    Interactive tool.
+    </help>
+</tool>

--- a/test/functional/tools/interactive_tools_cellxgene.xml
+++ b/test/functional/tools/interactive_tools_cellxgene.xml
@@ -1,0 +1,23 @@
+<tool id="interactive_tool_cellxgene" tool_type="realtime" name="Interactive CellXgene Environment" version="0.1">
+    <requirements>
+        <container type="docker">quay.io/galaxy/cellxgene-galaxy-ie:ie2</container>
+    </requirements>
+    <ports>
+        <port name="cellxgene_single_cell_visualisation" url="0.0.0.0">8080</port>
+    </ports>
+    <command>
+        cp '$input' /tmp/galaxy_cellxgene_${input.element_identifier}.h5ad;
+        /run_cellxgene.sh
+    </command>
+    <inputs>
+        <param name="input" type="data" format="h5ad" label="Concatenate Dataset"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    Interactive tool for visualising AnnData.
+    </help>
+</tool>


### PR DESCRIPTION
Hi @blankenberg,

thanks for this initial PR. It has been on our todo list for too long.

This PR is a proof of concept that the condor-runner could work as outlined. It actually demonstrates that this can be useful beyond the local runner. However, it uses a very condor-specific trick* and I'm not sure
we can easily adapt it to other runners. But I guess one productoin-ready runner is better than only the local runner.

A few unordered comments below. We are eager to help with this as much as we can. However, the timing is a little bit unforuntate ... GCC and so on...

* realtimetool is a very suboptimal name, every tool is real-time
* I think we should stick to the "Interactive" name and keep that branding in the community and migrate all internal IEs that are feasible to those tools, this could be a nice hackathon project
    * You raised the concern about your publication impact. I think you should be fine by naming the paper as you like, but the internals and
    how we communicate this to the users should stay as is, imho. I think the concept is the same from the user-pov and we should not add a new conceptual name.

- 127.0.0.1 does not work, 'localhost' works because of the hardcoded routes in galaxy.yml

- name="cellxgene_single_cell_visualisation_$input" -> the name in <port> should accept variables
- the `name` could allow cheetah variables, like `on_string` or the user-visible table could be extended to give a better idea which environment is actually running on which dataset

- the URL attribute was very confusing, at least for me, I change it to be more expressive to `url_entry_point`

- we lose some flexibility, for example, we can not easily change the `url` (url_entry_point) depending on the user-input (e.g. notebook included or not)

- we are now mounting in everything that a Job needs, this can be a security risk and we need to ensure that everything is read-only
  - not specific to these kind IEs, but because people can browse the filesystem now, it becomes more of a problem than from a normal tool
- to make it useful for RStudio and Jupyter, so environments that potentially want to have the entire history(s), we would need @erasche Docker-Fuse magic and additional infrastructure to squeeze in pre- and post- Docker commands

- why is the list of environments under User and not under Visualisation? Is that just to be different?

- the handling is quite unintuitive, you can not easily stop the environment from the history and ideally, such history elements would have
  a different style with a stop button instead of a remove button
- eye symbol should open the view, this is even more important than with traditional IEs, as this `dataset`-element does not need to do anything useful, it is the IE in many cases

- I'm still on the fence with myself how we should treat the longer runtime of a container and how to communicate the data handling.
  With traditional IEs we communicated clearly that an IE is only running as long as you see them, so backup your data it can be lost. With the long-running IEs, I fear that user does not backup their data,
  because they assume the job is still running in a few days. But in practice, the job-scheduler might kill the job because of the wall-time.
  - Running IEs, can waste a lot of money and compute capacity
  - people do not clean-up by themselves if they do not have any incentive
  - allow a configuration option for max IEs per user (possible now, but we need to put this in the docs imho)
  - Should we include a configurable, artificial runtime of a container? Let's say 1 day, configurable, we display the time in the list and give the user the possibility to reset the counter back to 1 day. But this means a user needs to at least hit the button once in a day.
    - we need to take the max walltime into account

- an infrastructure for authentification and passing in variables
  - Do we need to offer an infrastructure to password protect these environments
	- maybe this is not needed anymore with uwsgi?
  - we could add some tool attributes so that the API key, infrastructure_url, etc are plugged into the container during startup (e.g. <container_envs><container_env>infrastrucure_url</container_env></container_envs>)
  - but I'm laking a good idea of how we can log the user automatically in
  - this is blocking currently a full Jupyter implementation

ping @natefoo, @erasche and @jmchilton
ping @jxtx; included is the single-cell Vis as a proof of concept

`*` Condor has a feature/tool called `condor_ssh_to_job <condor_job_id> <command>` which is very handy. Given condor is configured correctly, we can use this to communicate directly to the Docker container running on a arbritrary host.
